### PR TITLE
Output collections in Galaxy

### DIFF
--- a/src/galaxy/je-demultiplex.xml
+++ b/src/galaxy/je-demultiplex.xml
@@ -74,6 +74,8 @@
             <param name="BM" value="BOTH"/>
             <param name="BRED" value="false"/>
 
+            <param name="COLLECT_OUTPUTS" value="false" />
+
             <param name="barcode_list_type_con" value="text"/>
             <param name="barcode_text"
                 value="sample1 CACTGT:GTATAG&#10;sample2 ATTCCG:TCCGTC&#10;sample3 GCTACC:TGGTCA&#10;sample4 CGAAAC:CACTGT"/>
@@ -89,6 +91,34 @@
                 <discovered_dataset designation="sample1_CACTGTGTATAG_2" file="sample1_CACTGTGTATAG_2.txt"/>
                 <discovered_dataset designation="sample1_CACTGTGTATAG_1" file="sample1_CACTGTGTATAG_1.txt"/>
             </output>
+        </test>
+        <test>
+            <!-- Repeat  of previous but with collection outputs -->
+            <param name="type" value="paired"/>
+            <param name="input_1" value="file_1_sequence.txt" ftype="fastqsanger"/>
+            <param name="input_2" value="file_2_sequence.txt" ftype="fastqsanger"/>
+
+            <param name="BPOS" value="BOTH"/>
+            <param name="BM" value="BOTH"/>
+            <param name="BRED" value="false"/>
+
+            <param name="barcode_list_type_con" value="text"/>
+            <param name="barcode_text"
+                   value="sample1 CACTGT:GTATAG&#10;sample2 ATTCCG:TCCGTC&#10;sample3 GCTACC:TGGTCA&#10;sample4 CGAAAC:CACTGT"/>
+            <param name="COLLECT_OUTPUTS" value="true" />
+
+            <output_collection name="COLLECTION_1" type="list">
+                <element name="sample1_CACTGTGTATAG_1.txt" value="sample4_CGAAACCACTGT_1.txt"/>
+                <element name="sample3_GCTACCTGGTCA_1.txt" value="sample3_GCTACCTGGTCA_1.txt"/>
+                <element name="sample2_ATTCCGTCCGTC_1.txt" value="sample2_ATTCCGTCCGTC_1.txt"/>
+                <element name="sample1_CACTGTGTATAG_1.txt" value="sample1_CACTGTGTATAG_1.txt"/>
+            </output_collection>
+            <output_collection name="COLLECTION_2" type="list">
+                <element name="sample4_CGAAACCACTGT_2.txt" value="sample4_CGAAACCACTGT_2.txt"/>
+                <element name="sample3_GCTACCTGGTCA_2.txt" value="sample3_GCTACCTGGTCA_2.txt"/>
+                <element name="sample2_ATTCCGTCCGTC_2.txt" value="sample2_ATTCCGTCCGTC_2.txt"/>
+                <element name="sample1_CACTGTGTATAG_2.txt" value="sample1_CACTGTGTATAG_2.txt"/>
+            </output_collection>
         </test>
     </tests>
 

--- a/src/galaxy/macros.xml
+++ b/src/galaxy/macros.xml
@@ -290,6 +290,8 @@ ${from_text_area}</configfile>
             falsevalue="false"
             checked="true"
         />
+        <param name="COLLECT_OUTPUTS" type="boolean" label="Group forward and reverse reads into seperate collection outputs?" />
+
         <section name="adv_options" title="Advanced Options" expanded="False">
             <param name="DIAG" type="boolean" label="Output barcode match reporting file (DIAG)"
                 truevalue="true" falsevalue="false" checked="false"
@@ -333,14 +335,24 @@ ${from_text_area}</configfile>
     <token name="@demultiplexer_common_outputs_cmd@">
         METRICS_FILE_NAME=$METRICS_FILE_NAME
     </token>
+    
     <xml name="demultiplexer_common_outputs">
         <data name="METRICS_FILE_NAME" format="tabular" label="Je-Demultiplex result">
+            <filter>COLLECT_OUTPUTS == False</filter>
             <!--<discover_datasets pattern="(?P&lt;name&gt;.*)\.txt" ext="fastqsanger"-->
             <discover_datasets pattern="(?P&lt;name&gt;.*)\.txt" directory="results" visible="true" ext="fastqsanger"/>
         </data>
         <data name="BARCODE_DIAG_FILE" format="tabular" label="Barcode statistics">
             <filter>(adv_options['DIAG'] == 'true')</filter>
         </data>
+        <collection name="COLLECTION_1" type="list" label="${tool.name} on ${on_string} : Reads_1" >
+            <filter>COLLECT_OUTPUTS</filter>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+_1\..+)" ext="fastqsangar" directory="results" visible="false" />
+        </collection>
+        <collection name="COLLECTION_2" type="list" label="${tool.name} on ${on_string} : Reads_2" >
+            <filter>COLLECT_OUTPUTS</filter>
+            <discover_datasets pattern="(?P&lt;designation&gt;.+_2\..+)" ext="fastqsangar" directory="results" visible="false" />
+        </collection>
     </xml>
     <xml name="citations">
         <citations>


### PR DESCRIPTION
Update to the Galaxy wrapper - option to group output FASTQ into R1 / R2 collections

